### PR TITLE
Fix the issue MCHANGES-398 that was caused by the change MPIR-323

### DIFF
--- a/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
@@ -191,7 +191,7 @@ public class ChangesMojo
      *
      * @since 2.4
      */
-    @Parameter( defaultValue = "team-list.html" )
+    @Parameter( defaultValue = "team.html" )
     private String teamlist;
 
     /**

--- a/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
@@ -192,7 +192,7 @@ public class ChangesMojo
      * @since 2.4
      */
     @Parameter( defaultValue = "team.html" )
-    private String teamlist;
+    private String team;
 
     /**
      */
@@ -328,7 +328,7 @@ public class ChangesMojo
 
         report.setSystem( system );
 
-        report.setTeamlist( teamlist );
+        report.setTeam( team );
 
         report.setUrl( url );
 
@@ -487,9 +487,9 @@ public class ChangesMojo
         return ResourceBundle.getBundle( "changes-report", locale, this.getClass().getClassLoader() );
     }
 
-    protected String getTeamlist()
+    protected String getTeam()
     {
-        return teamlist;
+        return team;
     }
 
     private void logIssueLinkTemplatePerSystem( Map<String, String> issueLinkTemplatePerSystem )

--- a/src/main/java/org/apache/maven/plugins/changes/ChangesReportGenerator.java
+++ b/src/main/java/org/apache/maven/plugins/changes/ChangesReportGenerator.java
@@ -60,7 +60,7 @@ public class ChangesReportGenerator
 
     static final String DEFAULT_ISSUE_SYSTEM_KEY = "default";
 
-    private static final String NO_TEAMLIST = "none";
+    private static final String NO_TEAM = "none";
 
     /**
      * The issue management system to use, for actions that do not specify a system.
@@ -69,7 +69,7 @@ public class ChangesReportGenerator
      */
     private String system;
 
-    private String teamlist;
+    private String team;
 
     private String url;
 
@@ -120,14 +120,14 @@ public class ChangesReportGenerator
         this.system = system;
     }
 
-    public void setTeamlist( final String teamlist )
+    public void setTeam( final String team )
     {
-        this.teamlist = teamlist;
+        this.team = team;
     }
 
-    public String getTeamlist()
+    public String getTeam()
     {
-        return teamlist;
+        return team;
     }
 
     public void setUrl( String url )
@@ -287,13 +287,13 @@ public class ChangesReportGenerator
 
         sink.tableCell_();
 
-        if ( NO_TEAMLIST.equals( teamlist ) )
+        if ( NO_TEAM.equals( team ) )
         {
             sinkCell( sink, action.getDev() );
         }
         else
         {
-            sinkCellLink( sink, action.getDev(), teamlist + "#" + action.getDev() );
+            sinkCellLink( sink, action.getDev(), team + "#" + action.getDev() );
         }
 
         if ( this.isAddActionDate() )

--- a/src/main/mdo/changes.mdo
+++ b/src/main/mdo/changes.mdo
@@ -271,7 +271,7 @@ under the License.
           <description>
             <![CDATA[
             Name of developer who committed the change.
-            <p>This can be either the id of the developer, as specified in the developers section of the pom.xml file, or the name of the developer. If you generate a changes report and specify the id of the developer, a link is created to that developer in the team-list.html page.</p>
+            <p>This can be either the id of the developer, as specified in the developers section of the pom.xml file, or the name of the developer. If you generate a changes report and specify the id of the developer, a link is created to that developer in the team.html page.</p>
             ]]>
           </description>
         </field>


### PR DESCRIPTION
A fix for the issue MCHANGES-398 which was caused by the change MPIR-323 to Maven Project Info Reports Plugin. Now the default page for the team list is "team.html" and no more "team-list.html".