### PR TITLE
[MCHANGES-309] - RestJiraDownloader does not handle explicit JSON nul…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,12 @@ under the License.
       <version>${wagonVersion}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock</artifactId>
+      <version>1.49</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/apache/maven/plugins/jira/RestJiraDownloader.java
+++ b/src/main/java/org/apache/maven/plugins/jira/RestJiraDownloader.java
@@ -184,7 +184,7 @@ public class RestJiraDownloader
             JsonNode errorTree = getResponseTree( resp );
             assert errorTree.isObject();
             JsonNode messages = errorTree.get( "errorMessages" );
-            if ( messages != null )
+            if ( !isNullNode( messages ) )
             {
                 for ( int mx = 0; mx < messages.size(); mx++ )
                 {
@@ -194,7 +194,7 @@ public class RestJiraDownloader
             else
             {
                 JsonNode message = errorTree.get( "message" );
-                if ( message != null )
+                if ( !isNullNode( message ) )
                 {
                     getLog().error( message.asText() );
                 }
@@ -284,13 +284,13 @@ public class RestJiraDownloader
             JsonNode val;
 
             val = issueNode.get( "id" );
-            if ( val != null )
+            if ( !isNullNode( val ) )
             {
                 issue.setId( val.asText() );
             }
 
             val = issueNode.get( "key" );
-            if ( val != null )
+            if ( !isNullNode( val ) )
             {
                 issue.setKey( val.asText() );
                 issue.setLink( String.format( "%s/browse/%s", jiraUrl, val.asText() ) );
@@ -330,13 +330,13 @@ public class RestJiraDownloader
             processStatus( issue, val );
 
             val = fieldsNode.get( "summary" );
-            if ( val != null )
+            if ( !isNullNode( val ) )
             {
                 issue.setSummary( val.asText() );
             }
 
             val = fieldsNode.get( "title" );
-            if ( val != null )
+            if ( !isNullNode( val ) )
             {
                 issue.setTitle( val.asText() );
             }
@@ -354,7 +354,7 @@ public class RestJiraDownloader
     private void processVersions( Issue issue, JsonNode val )
     {
         StringBuilder sb = new StringBuilder();
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             for ( int vx = 0; vx < val.size(); vx++ )
             {
@@ -371,7 +371,7 @@ public class RestJiraDownloader
 
     private void processStatus( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             issue.setStatus( val.get( "name" ).asText() );
         }
@@ -379,7 +379,7 @@ public class RestJiraDownloader
 
     private void processPriority( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             issue.setPriority( val.get( "name" ).asText() );
         }
@@ -387,7 +387,7 @@ public class RestJiraDownloader
 
     private void processResolution( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             issue.setResolution( val.get( "name" ).asText() );
         }
@@ -396,11 +396,11 @@ public class RestJiraDownloader
     private String getPerson( JsonNode val )
     {
         JsonNode nameNode = val.get( "displayName" );
-        if ( nameNode == null )
+        if ( isNullNode( nameNode ) )
         {
             nameNode = val.get( "name" );
         }
-        if ( nameNode != null )
+        if ( !isNullNode( val ) )
         {
             return nameNode.asText();
         }
@@ -412,7 +412,7 @@ public class RestJiraDownloader
 
     private void processAssignee( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             String text = getPerson( val );
             if ( text != null )
@@ -424,7 +424,7 @@ public class RestJiraDownloader
 
     private void processReporter( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             String text = getPerson( val );
             if ( text != null )
@@ -436,7 +436,7 @@ public class RestJiraDownloader
 
     private void processCreated( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             try
             {
@@ -451,7 +451,7 @@ public class RestJiraDownloader
 
     private void processUpdated( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             try
             {
@@ -472,7 +472,7 @@ public class RestJiraDownloader
 
     private void processFixVersions( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             assert val.isArray();
             for ( int vx = 0; vx < val.size(); vx++ )
@@ -485,7 +485,7 @@ public class RestJiraDownloader
 
     private void processComments( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             JsonNode commentsArray = val.get( "comments" );
             for ( int cx = 0; cx < commentsArray.size(); cx++ )
@@ -498,7 +498,7 @@ public class RestJiraDownloader
 
     private void processComponents( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             assert val.isArray();
             for ( int cx = 0; cx < val.size(); cx++ )
@@ -511,7 +511,7 @@ public class RestJiraDownloader
 
     private void processIssueType( Issue issue, JsonNode val )
     {
-        if ( val != null )
+        if ( !isNullNode( val ) )
         {
             issue.setType( val.get( "name" ).asText() );
         }
@@ -606,5 +606,10 @@ public class RestJiraDownloader
     public List<Issue> getIssueList()
     {
         return issueList;
+    }
+
+    private boolean isNullNode( JsonNode val )
+    {
+        return val == null || val.isNull();
     }
 }

--- a/src/test/java/javax/annotation/Resource.java
+++ b/src/test/java/javax/annotation/Resource.java
@@ -1,0 +1,32 @@
+package javax.annotation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugins.jira.RestJiraDownloaderTest;
+
+/**
+ * This is a stub/fake annotation used by {@link RestJiraDownloaderTest}.
+ *
+ * org.apache.cxf.common.injection.ResourceInjector requires it, and will throw NoClassDefFoundError if it's absent. However, I
+ * can't add real javax annotations as a test dependency, because maven enforcer plugin prohibits me.
+ */
+public @interface Resource
+{
+}

--- a/src/test/java/javax/annotation/Resources.java
+++ b/src/test/java/javax/annotation/Resources.java
@@ -1,0 +1,32 @@
+package javax.annotation;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.plugins.jira.RestJiraDownloaderTest;
+
+/**
+ * This is a stub/fake annotation used by {@link RestJiraDownloaderTest}.
+ *
+ * org.apache.cxf.common.injection.ResourceInjector requires it, and will throw NoClassDefFoundError if it's absent. However, I
+ * can't add real javax annotations as a test dependency, because maven enforcer plugin prohibits me.
+ */
+public @interface Resources
+{
+}

--- a/src/test/java/org/apache/maven/plugins/jira/RestJiraDownloaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/jira/RestJiraDownloaderTest.java
@@ -1,0 +1,88 @@
+package org.apache.maven.plugins.jira;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.maven.model.IssueManagement;
+import org.apache.maven.plugin.testing.SilentLog;
+import org.apache.maven.plugins.issues.Issue;
+import org.apache.maven.project.MavenProject;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.junit.Assert.*;
+
+public class RestJiraDownloaderTest
+{
+    private static final int PORT = 3033;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(3033);
+
+    @Test
+    public void getIssues() throws Exception
+    {
+        stubFor(
+            get(urlEqualTo("/rest/api/2/serverInfo"))
+                .willReturn(
+                    aResponse().withHeader("Content-Type", APPLICATION_JSON)
+                )
+        );
+        stubFor(
+            post(urlEqualTo("/rest/api/2/search"))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", APPLICATION_JSON)
+                        .withBody("{\"issues\": [{\"id\": \"some-id\", \"key\": null, \"fields\": { \"resolution\": null } }]}")
+                )
+        );
+
+        RestJiraDownloader downloader = getDownloader();
+        downloader.doExecute();
+
+        List<Issue> issueList = downloader.getIssueList();
+        assertEquals( 1, issueList.size() );
+        Issue issue = issueList.get( 0 );
+        assertEquals( "some-id", issue.getId() );
+    }
+
+    private static RestJiraDownloader getDownloader()
+    {
+        IssueManagement issueManagement = new IssueManagement();
+        issueManagement.setUrl( "http://localhost:" + PORT + "/browse/" );
+
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.setIssueManagement( issueManagement );
+
+        RestJiraDownloader downloader = new RestJiraDownloader();
+        downloader.setMavenProject( mavenProject );
+        downloader.setLog( new SilentLog() );
+
+        return downloader;
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/jira/RestJiraDownloaderTest.java
+++ b/src/test/java/org/apache/maven/plugins/jira/RestJiraDownloaderTest.java
@@ -42,23 +42,23 @@ public class RestJiraDownloaderTest
     private static final int PORT = 3033;
 
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(3033);
+    public WireMockRule wireMockRule = new WireMockRule( PORT );
 
     @Test
     public void getIssues() throws Exception
     {
         stubFor(
-            get(urlEqualTo("/rest/api/2/serverInfo"))
+            get( urlEqualTo( "/rest/api/2/serverInfo" ) )
                 .willReturn(
-                    aResponse().withHeader("Content-Type", APPLICATION_JSON)
+                    aResponse().withHeader( "Content-Type", APPLICATION_JSON )
                 )
         );
         stubFor(
-            post(urlEqualTo("/rest/api/2/search"))
+            post( urlEqualTo( "/rest/api/2/search" ) )
                 .willReturn(
                     aResponse()
-                        .withHeader("Content-Type", APPLICATION_JSON)
-                        .withBody("{\"issues\": [{\"id\": \"some-id\", \"key\": null, \"fields\": { \"resolution\": null } }]}")
+                        .withHeader( "Content-Type", APPLICATION_JSON )
+                        .withBody( "{\"issues\": [{\"id\": \"some-id\", \"key\": null, \"fields\": { \"resolution\": null } }]}" )
                 )
         );
 


### PR DESCRIPTION
…l values

https://issues.apache.org/jira/browse/MCHANGES-309

I have introduced [WireMock](http://wiremock.org/) as a test dependency to test this. Short of completely refactoring the whole class, there is no other workable approach, because the logic which creates an HTTP client is completely encapsulated.

I had to choose a relatively old version of WireMock because there were incompatibilities (manifesting as class not found exceptions) between the plugin's version of Apache HTTP client (**4.2.3**), and the one that the latest WireMock version wanted (**4.5.12**). In the end I went with the oldest version of WireMock that uses the exact same version that we use. It's conceivable we could get away with a newer version of WireMock than this, but I didn't have the energy to try to them exhaustively.

The latest WireMock can choose a dynamic port, rather than the hard-coded one I chose here. That's the only feature I would have used but couldn't.


Some Apache class (ResourceInjector) requires javax annotations on the classpath for this test to pass, and they were not present. When I added the dependency with test scope, i.e.

```xml
<dependency>
    <groupId>javax.annotation</groupId>
    <artifactId>javax.annotation-api</artifactId>
    <version>1.3.1</version>
    <scope>test</scope>
</dependency>
```

The Maven Enforcer plugin complained

```
Found Banned Dependency: javax.annotation:javax.annotation-api:jar:1.3.1
```

So the workaround I used was to add fake/stubbed version of the required annotations in the test directory. I appreciate that this is a bit hacky, but I've added JavaDocs to them to explain their purpose. 

If it's possible to change the enforcer rules to allow the real javax annotations in this case, I would prefer that. Changing the enforcer rules seems beyond my remit so I did not.