### PR TITLE
remove misleading comment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,6 @@ under the License.
         </exclusion>
       </exclusions>
     </dependency>
-    <!--  javamail to parse an email address -->
     <dependency>
       <groupId>org.apache.geronimo.javamail</groupId>
       <artifactId>geronimo-javamail_1.4_provider</artifactId>


### PR DESCRIPTION
javax.mail is used in this plugin to send, not simply to parse email addresses