### PR TITLE
Fix a file handle leak on exception

### DIFF
--- a/src/main/java/org/apache/maven/plugins/announcement/AnnouncementMailMojo.java
+++ b/src/main/java/org/apache/maven/plugins/announcement/AnnouncementMailMojo.java
@@ -364,7 +364,6 @@ public class AnnouncementMailMojo
     protected String readAnnouncement( File file )
         throws MojoExecutionException
     {
-        InputStreamReader reader = null;
         try
         {
             if ( StringUtils.isEmpty( templateEncoding ) )
@@ -375,11 +374,10 @@ public class AnnouncementMailMojo
 
             }
 
-            reader = new InputStreamReader( new FileInputStream( file ), templateEncoding );
-            final String announcement = IOUtil.toString( reader );
-            reader.close();
-            reader = null;
-            return announcement;
+            try ( InputStreamReader reader = new InputStreamReader( new FileInputStream( file ), templateEncoding ) )
+            {
+                return IOUtil.toString( reader );
+            }
         }
         catch ( FileNotFoundException fnfe )
         {
@@ -392,10 +390,6 @@ public class AnnouncementMailMojo
         catch ( IOException ioe )
         {
             throw new MojoExecutionException( "Failed to read the announcement file.", ioe );
-        }
-        finally
-        {
-            IOUtil.close( reader );
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
@@ -47,7 +47,6 @@ import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFileFilterRequest;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -408,30 +407,25 @@ public class ChangesMojo
             {
                 filteredOutputDirectory.mkdirs();
             }
-            XmlStreamReader xmlStreamReader = null;
             try
             {
                 // so we get encoding from the file itself
-                xmlStreamReader = new XmlStreamReader( changesXml );
-                String encoding = xmlStreamReader.getEncoding();
-                File resultFile = new File( filteredOutputDirectory,
+                try ( XmlStreamReader xmlStreamReader = new XmlStreamReader( changesXml ) )
+                {
+                    String encoding = xmlStreamReader.getEncoding();
+                    File resultFile = new File( filteredOutputDirectory,
                                             project.getGroupId() + "." + project.getArtifactId() + "-changes.xml" );
 
-                final MavenFileFilterRequest mavenFileFilterRequest =
-                    new MavenFileFilterRequest( changesXml, resultFile, true, project, Collections.<String>emptyList(),
-                                                false, encoding, session, additionalProperties );
-                mavenFileFilter.copyFile( mavenFileFilterRequest );
-                changesXml = resultFile;
-                xmlStreamReader.close();
-                xmlStreamReader = null;
+                    final MavenFileFilterRequest mavenFileFilterRequest =
+                            new MavenFileFilterRequest( changesXml, resultFile, true, project, 
+                                    Collections.<String>emptyList(), false, encoding, session, additionalProperties );
+                    mavenFileFilter.copyFile( mavenFileFilterRequest );
+                    changesXml = resultFile;
+                }
             }
             catch ( IOException | MavenFilteringException e )
             {
                 throw new MavenReportException( "Exception during filtering changes file : " + e.getMessage(), e );
-            }
-            finally
-            {
-                IOUtil.close( xmlStreamReader );
             }
 
         }

--- a/src/main/java/org/apache/maven/plugins/changes/ChangesXML.java
+++ b/src/main/java/org/apache/maven/plugins/changes/ChangesXML.java
@@ -49,7 +49,6 @@ import org.apache.maven.plugins.changes.model.ChangesDocument;
 import org.apache.maven.plugins.changes.model.Properties;
 import org.apache.maven.plugins.changes.model.Release;
 import org.apache.maven.plugins.changes.model.io.xpp3.ChangesXpp3Reader;
-import org.codehaus.plexus.util.IOUtil;
 
 /**
  * A facade for a changes.xml file.
@@ -91,17 +90,15 @@ public class ChangesXML
             return;
         }
 
-        FileInputStream fileInputStream = null;
-
         try
         {
 
             ChangesXpp3Reader reader = new ChangesXpp3Reader();
 
-            fileInputStream = new FileInputStream( xmlPath );
-            changesDocument = reader.read( fileInputStream, false );
-            fileInputStream.close();
-            fileInputStream = null;
+            try ( FileInputStream fileInputStream = new FileInputStream( xmlPath ) )
+            {
+                changesDocument = reader.read( fileInputStream, false );
+            }
 
             if ( changesDocument == null )
             {
@@ -133,10 +130,6 @@ public class ChangesXML
         {
             log.error( "An error occurred when parsing the changes.xml file: ", e );
             throw new ChangesXMLRuntimeException( "An error occurred when parsing the changes.xml file", e );
-        }
-        finally
-        {
-            IOUtil.close( fileInputStream );
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/changes/schema/DefaultChangesSchemaValidator.java
+++ b/src/main/java/org/apache/maven/plugins/changes/schema/DefaultChangesSchemaValidator.java
@@ -56,7 +56,6 @@ public class DefaultChangesSchemaValidator
     public XmlValidationHandler validateXmlWithSchema( File file, String schemaVersion, boolean failOnValidationError )
         throws SchemaValidatorException
     {
-        Reader reader = null;
         try
         {
             String schemaPath = CHANGES_SCHEMA_PATH + "changes-" + schemaVersion + ".xsd";
@@ -69,12 +68,10 @@ public class DefaultChangesSchemaValidator
 
             validator.setErrorHandler( baseHandler );
 
-            reader = new XmlStreamReader( file );
-
-            validator.validate( new StreamSource( reader ) );
-
-            reader.close();
-            reader = null;
+            try ( Reader reader = new XmlStreamReader( file ) )
+            {
+                validator.validate( new StreamSource( reader ) );
+            }
 
             return baseHandler;
         }
@@ -89,10 +86,6 @@ public class DefaultChangesSchemaValidator
         catch ( Exception e )
         {
             throw new SchemaValidatorException( "Exception : " + e.getMessage(), e );
-        }
-        finally
-        {
-            IOUtil.close( reader );
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/jira/RestJiraDownloader.java
+++ b/src/main/java/org/apache/maven/plugins/jira/RestJiraDownloader.java
@@ -143,16 +143,17 @@ public class RestJiraDownloader
             .build();
 
         StringWriter searchParamStringWriter = new StringWriter();
-        JsonGenerator gen = jsonFactory.createGenerator( searchParamStringWriter );
-        gen.writeStartObject();
-        gen.writeStringField( "jql", jqlQuery );
-        gen.writeNumberField( "maxResults", nbEntriesMax );
-        gen.writeArrayFieldStart( "fields" );
-        // Retrieve all fields. If that seems slow, we can reconsider.
-        gen.writeString( "*all" );
-        gen.writeEndArray();
-        gen.writeEndObject();
-        gen.close();
+        try ( JsonGenerator gen = jsonFactory.createGenerator( searchParamStringWriter ) ) 
+        {
+            gen.writeStartObject();
+            gen.writeStringField( "jql", jqlQuery );
+            gen.writeNumberField( "maxResults", nbEntriesMax );
+            gen.writeArrayFieldStart( "fields" );
+            // Retrieve all fields. If that seems slow, we can reconsider.
+            gen.writeString( "*all" );
+            gen.writeEndArray();
+            gen.writeEndObject();
+        }
         client.replacePath( "/rest/api/2/search" );
         client.type( MediaType.APPLICATION_JSON_TYPE );
         client.accept( MediaType.APPLICATION_JSON_TYPE );
@@ -526,12 +527,13 @@ public class RestJiraDownloader
             client.replacePath( "/rest/auth/1/session" );
             client.type( MediaType.APPLICATION_JSON_TYPE );
             StringWriter jsWriter = new StringWriter();
-            JsonGenerator gen = jsonFactory.createGenerator( jsWriter );
-            gen.writeStartObject();
-            gen.writeStringField( "username", jiraUser );
-            gen.writeStringField( "password", jiraPassword );
-            gen.writeEndObject();
-            gen.close();
+            try ( JsonGenerator gen = jsonFactory.createGenerator( jsWriter ) )
+            {
+                gen.writeStartObject();
+                gen.writeStringField( "username", jiraUser ) ;
+                gen.writeStringField( "password", jiraPassword );
+                gen.writeEndObject();
+            }
             Response authRes = client.post( jsWriter.toString() );
             if ( authRes.getStatus() != Response.Status.OK.getStatusCode() )
             {

--- a/src/test/java/org/apache/maven/plugins/announcement/AnnouncementMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/announcement/AnnouncementMojoTest.java
@@ -20,11 +20,10 @@ package org.apache.maven.plugins.announcement;
  */
 
 import java.io.File;
-import java.io.FileReader;
+import java.nio.file.Files;
 
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.IOUtil;
 
 /**
  * @author Olivier Lamy
@@ -62,10 +61,7 @@ public class AnnouncementMojoTest
         setVariableValueToObject( mojo, "introduction", "Nice library" );
         mojo.execute();
 
-        FileReader fileReader = new FileReader( new File( announcementDirectory, "announcement.vm" ) );
-        String result = IOUtil.toString( fileReader );
-
-        fileReader.close();
+        String result = new String( Files.readAllBytes( announcementDirectory.toPath().resolve( "announcement.vm" ) ) );
 
         assertContains( "Nice library", result );
 

--- a/src/test/java/org/apache/maven/plugins/changes/FeedGeneratorTest.java
+++ b/src/test/java/org/apache/maven/plugins/changes/FeedGeneratorTest.java
@@ -29,7 +29,6 @@ import java.util.Locale;
 
 import junit.framework.TestCase;
 
-import org.apache.maven.plugins.changes.FeedGenerator;
 import org.apache.maven.plugins.changes.model.Release;
 
 /**
@@ -94,12 +93,13 @@ public class FeedGeneratorTest
 
         for ( String type : generator.getSupportedFeedTypes() )
         {
-            Writer writer = new StringWriter( 512 );
-            generator.export( releases, type, writer );
-            String result = writer.toString(); // TODO: save for inspection?
-            assertNotNull( result );
-            assertTrue( result.length() > 0 );
-            writer.close();
+            try ( Writer writer = new StringWriter( 512 ) )
+            {
+                generator.export( releases, type, writer );
+                String result = writer.toString(); // TODO: save for inspection?
+                assertNotNull( result );
+                assertTrue( result.length() > 0 );
+            }
         }
     }
 }

--- a/src/test/java/org/apache/maven/plugins/jira/JiraUnicodeTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/jira/JiraUnicodeTestCase.java
@@ -59,12 +59,9 @@ public class JiraUnicodeTestCase
         repoSession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( "target/local-repo" ) );
         setVariableValueToObject( mojo, "project", project );
         setVariableValueToObject( mojo, "mavenSession", session );
-        InputStream testJiraXmlStream = JiraUnicodeTestCase.class.getResourceAsStream( "unicode-jira-results.xml" );
         String jiraXml;
-        try {
+        try (InputStream testJiraXmlStream = JiraUnicodeTestCase.class.getResourceAsStream( "unicode-jira-results.xml" ) ) {
             jiraXml = IOUtils.toString(testJiraXmlStream, UTF_8 );
-        } finally {
-            testJiraXmlStream.close();
         }
 
         MockJiraDownloader mockDownloader = new MockJiraDownloader();


### PR DESCRIPTION
Fix a file handle leak when exceptions are thrown in `RestJiraDownloader` and use try-with-resources in select other files.
