### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/src/main/java/org/apache/maven/plugins/announcement/AnnouncementMailMojo.java
+++ b/src/main/java/org/apache/maven/plugins/announcement/AnnouncementMailMojo.java
@@ -43,7 +43,6 @@ import org.codehaus.plexus.mailsender.MailMessage;
 import org.codehaus.plexus.mailsender.MailSenderException;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Goal which sends an announcement through email.
@@ -366,7 +365,7 @@ public class AnnouncementMailMojo
     {
         try
         {
-            if ( StringUtils.isEmpty( templateEncoding ) )
+            if ( templateEncoding == null || templateEncoding.isEmpty() )
             {
                 templateEncoding = ReaderFactory.FILE_ENCODING;
                 getLog().warn( "File encoding has not been set, using platform encoding '" + templateEncoding

--- a/src/main/java/org/apache/maven/plugins/announcement/AnnouncementMojo.java
+++ b/src/main/java/org/apache/maven/plugins/announcement/AnnouncementMojo.java
@@ -58,7 +58,6 @@ import org.apache.velocity.exception.ResourceNotFoundException;
 import org.apache.velocity.exception.VelocityException;
 import org.apache.velocity.tools.ToolManager;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.velocity.VelocityComponent;
 
 /**
@@ -696,7 +695,7 @@ public class AnnouncementMojo
         File f;
 
         // Use the name of the template as a default value
-        if ( StringUtils.isEmpty( announcementFile ) )
+        if ( announcementFile == null || announcementFile.isEmpty() )
         {
             announcementFile = template;
         }
@@ -714,7 +713,7 @@ public class AnnouncementMojo
 
             engine.setApplicationAttribute( "baseDirectory", basedir );
 
-            if ( StringUtils.isEmpty( templateEncoding ) )
+            if ( templateEncoding == null || templateEncoding.isEmpty() )
             {
                 templateEncoding = ReaderFactory.FILE_ENCODING;
                 getLog().warn( "File encoding has not been set, using platform encoding " + templateEncoding
@@ -804,7 +803,7 @@ public class AnnouncementMojo
 
             List<Issue> issueList = jiraDownloader.getIssueList();
 
-            if ( StringUtils.isNotEmpty( versionPrefix ) )
+            if ( versionPrefix != null && !versionPrefix.isEmpty() )
             {
                 int originalNumberOfIssues = issueList.size();
                 issueList = IssueUtils.filterIssuesWithVersionPrefix( issueList, versionPrefix );

--- a/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/changes/ChangesMojo.java
@@ -47,7 +47,6 @@ import org.apache.maven.shared.filtering.MavenFileFilter;
 import org.apache.maven.shared.filtering.MavenFileFilterRequest;
 import org.apache.maven.shared.filtering.MavenFilteringException;
 import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * Goal which creates a nicely formatted Changes Report in html format from a changes.xml file.
@@ -334,14 +333,14 @@ public class ChangesMojo
 
         report.setAddActionDate( addActionDate );
 
-        if ( StringUtils.isEmpty( url ) )
+        if ( url == null || url.isEmpty() )
         {
             getLog().warn( "No issue management URL defined in POM. Links to your issues will not work correctly." );
         }
 
         boolean feedGenerated = false;
 
-        if ( StringUtils.isNotEmpty( feedType ) )
+        if ( feedType != null && !feedType.isEmpty() )
         {
             feedGenerated = generateFeed( changesXml, locale );
         }

--- a/src/main/java/org/apache/maven/plugins/issues/AbstractIssuesReportGenerator.java
+++ b/src/main/java/org/apache/maven/plugins/issues/AbstractIssuesReportGenerator.java
@@ -22,7 +22,6 @@ package org.apache.maven.plugins.issues;
 import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.doxia.sink.SinkEventAttributes;
 import org.apache.maven.doxia.sink.impl.SinkEventAttributeSet;
-import org.codehaus.plexus.util.StringUtils;
 
 import java.util.ResourceBundle;
 
@@ -80,7 +79,7 @@ public abstract class AbstractIssuesReportGenerator
         sink.text( title );
         sink.title_();
 
-        if ( StringUtils.isNotEmpty( author ) )
+        if ( author != null && !author.isEmpty() )
         {
             sink.author();
             sink.text( author );

--- a/src/main/java/org/apache/maven/plugins/trac/TracDownloader.java
+++ b/src/main/java/org/apache/maven/plugins/trac/TracDownloader.java
@@ -122,7 +122,7 @@ public class TracDownloader
         // Fetch issues
         String qstr = "";
 
-        if ( !(query == null || query.isEmpty()) )
+        if ( !( query == null || query.isEmpty() ) )
         {
             qstr = query;
         }

--- a/src/main/java/org/apache/maven/plugins/trac/TracDownloader.java
+++ b/src/main/java/org/apache/maven/plugins/trac/TracDownloader.java
@@ -25,7 +25,6 @@ import org.apache.xmlrpc.XmlRpcException;
 import org.apache.xmlrpc.client.XmlRpcClient;
 import org.apache.xmlrpc.client.XmlRpcClientConfigImpl;
 import org.apache.xmlrpc.client.XmlRpcCommonsTransportFactory;
-import org.codehaus.plexus.util.StringUtils;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -123,7 +122,7 @@ public class TracDownloader
         // Fetch issues
         String qstr = "";
 
-        if ( !StringUtils.isEmpty( query ) )
+        if ( !(query == null || query.isEmpty()) )
         {
             qstr = query;
         }


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu