### PR TITLE
[MCHANGES-419] Make IssueAdapter#getReleases return releases in a sensible order.

### DIFF
--- a/src/main/java/org/apache/maven/plugins/changes/IssueAdapter.java
+++ b/src/main/java/org/apache/maven/plugins/changes/IssueAdapter.java
@@ -19,15 +19,18 @@ package org.apache.maven.plugins.changes;
  * under the License.
  */
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.apache.maven.plugins.changes.model.Action;
 import org.apache.maven.plugins.changes.model.Release;
 import org.apache.maven.plugins.issues.Issue;
 import org.apache.maven.plugins.issues.IssueManagementSystem;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * An adapter that can adapt data models from other issue management system to the data models used in the changes.xml
@@ -94,8 +97,21 @@ public class IssueAdapter
             }
         }
 
-        // Extract the releases from the Map to a List
-        return new ArrayList<>( releasesMap.values() );
+        // Extract the releases from the Map to a sorted List. Releases are sorted by descending order of version.
+        ArrayList<Release> allReleases = new ArrayList<>( releasesMap.values() );
+        Collections.sort( allReleases, new Comparator<Release>()
+        {
+            @Override
+            public int compare( Release release1, Release release2 )
+            {
+                ComparableVersion version1 = new ComparableVersion( release1.getVersion() );
+                ComparableVersion version2 = new ComparableVersion( release2.getVersion() );
+
+                return version2.compareTo( version1 );
+            }
+        } );
+
+        return allReleases;
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugins/changes/IssueAdapterTest.java
+++ b/src/test/java/org/apache/maven/plugins/changes/IssueAdapterTest.java
@@ -19,22 +19,22 @@ package org.apache.maven.plugins.changes;
  * under the License.
  */
 
-import org.apache.maven.plugins.changes.IssueAdapter;
-import org.apache.maven.plugins.changes.IssueType;
+import java.util.Arrays;
+import java.util.List;
+
+import junit.framework.TestCase;
 import org.apache.maven.plugins.changes.model.Action;
+import org.apache.maven.plugins.changes.model.Release;
 import org.apache.maven.plugins.issues.Issue;
 import org.apache.maven.plugins.issues.IssueManagementSystem;
 import org.apache.maven.plugins.jira.JIRAIssueManagmentSystem;
-
-import junit.framework.TestCase;
 
 /**
  * @author Alan Parkinson
  * @version $Id$
  * @since 2.6
  */
-public class IssueAdapterTest
-    extends TestCase
+public class IssueAdapterTest extends TestCase
 {
 
     public void testDefaultIssueTypeMapping()
@@ -115,11 +115,45 @@ public class IssueAdapterTest
 
     private Issue createIssue( String key, String type )
     {
+        return createIssue( key, type, null );
+    }
+
+    private Issue createIssue( String key, String type, String version )
+    {
         Issue issue = new Issue();
         issue.setKey( key );
         issue.setType( type );
+        if ( version != null )
+        {
+            issue.addFixVersion( version );
+        }
+
         issue.setAssignee( "A User" );
         issue.setSummary( "The title of this issue" );
         return issue;
+    }
+
+    public void testReleaseOrder()
+    {
+        IssueManagementSystem ims = new JIRAIssueManagmentSystem();
+        ims.getIssueTypeMap().put( "Story", IssueType.ADD );
+        ims.getIssueTypeMap().put( "Epic", IssueType.ADD );
+        ims.getIssueTypeMap().put( "Defect", IssueType.FIX );
+        ims.getIssueTypeMap().put( "Error", IssueType.FIX );
+        IssueAdapter adapter = new IssueAdapter( ims );
+
+        List<Issue> issues =
+                Arrays.asList( createIssue( "TST-1", "Story", "1.0.0-alpha" ), createIssue( "TST-2", "Epic", "1.2.1" ),
+                        createIssue( "TST-3", "Error", "0.1.1" ), createIssue( "TST-4", "Defect", "3.0" ),
+                        createIssue( "TST-5", "Improvement", "4" ), createIssue( "TST-6", "Epic", "0.1.1" ) );
+
+        List<Release> releases = adapter.getReleases( issues );
+
+        assertEquals( releases.size(), 5 );
+        assertEquals( releases.get( 0 ).getVersion(), "4" );
+        assertEquals( releases.get( 1 ).getVersion(), "3.0" );
+        assertEquals( releases.get( 2 ).getVersion(), "1.2.1" );
+        assertEquals( releases.get( 3 ).getVersion(), "1.0.0-alpha" );
+        assertEquals( releases.get( 4 ).getVersion(), "0.1.1" );
     }
 }


### PR DESCRIPTION
The list of releases is provided to the velocity template as $releases, however this list is unsorted (as per Map#values documentation).

Because velocity doesn't allow you to easily sort version strings, it seems to make sense to me that they are provided in descending order to velocity. 

The use-case is to generate reports/announcements containing changes for all releases. 