### PR TITLE
Declare used slf4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -353,12 +353,6 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <version>3.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>4.0.0-alpha-2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -348,7 +348,7 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
+      <artifactId>hamcrest-core</artifactId>
       <version>3.0</version>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,11 @@ under the License.
       <artifactId>jsr311-api</artifactId>
       <version>1.1.1</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+    </dependency>
 
     <!-- commons -->
     <dependency>
@@ -339,6 +344,12 @@ under the License.
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -254,11 +254,6 @@ under the License.
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-      <version>1.1.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.36</version>


### PR DESCRIPTION
FYI, this project tickles a bug in the maven-dependency-analyzer I thought I had fixed where it reports hamcrest as used but undeclared and hamcrest-core as unused but declared. Then, when I fix that, it reports hamcrest-core as used but undeclared and hamcrest as unused but declared. I'll have to fix this in the dependency analyzer (or maybe just release a new version?) before we can enforce dependency declarations in this project. Still, we might as well declare what we can for now.

Upgrading to JUnit 5 might help. 

