### PR TITLE
[MCHANGES-462] Remove Hamcrest dependency to avoid dependency analyzer warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,8 +334,8 @@ under the License.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
       <!-- matches version from JUnit -->
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -183,16 +183,6 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.javamail</groupId>
-      <artifactId>geronimo-javamail_1.4_provider</artifactId>
-      <version>1.8.4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-javamail_1.4_spec</artifactId>
-      <version>1.7.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geronimo.javamail</groupId>
       <artifactId>geronimo-javamail_1.4_mail</artifactId>
       <version>1.8.4</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -332,13 +332,6 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <!-- matches version from JUnit -->
-      <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>4.0.0-alpha-2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@ under the License.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>1.3</version> <!-- matches version from JUnit -->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,8 @@ under the License.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version> <!-- matches version from JUnit -->
+      <version>1.3</version>
+      <!-- matches version from JUnit -->
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,16 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.javamail</groupId>
+      <artifactId>geronimo-javamail_1.4_provider</artifactId>
+      <version>1.8.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-javamail_1.4_spec</artifactId>
+      <version>1.7.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.javamail</groupId>
       <artifactId>geronimo-javamail_1.4_mail</artifactId>
       <version>1.8.4</version>
     </dependency>
@@ -334,7 +344,7 @@ under the License.
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>3.0</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/apache/maven/plugins/changes/ChangesCheckMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/changes/ChangesCheckMojoTestCase.java
@@ -20,10 +20,9 @@ package org.apache.maven.plugins.changes;
 
 import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author Dennis Lundberg
@@ -113,7 +112,7 @@ public class ChangesCheckMojoTestCase {
     public void testCompat() {
         // @TODO fix for Java 9+
         // System.setProperty( "java.locale.providers", "COMPAT,CLDR" ) is not picked up...
-        assumeThat(System.getProperty("java.version"), startsWith("1."));
+        assumeTrue(System.getProperty("java.version").startsWith("1."));
 
         // pattern with months as text
         String pattern = "dd MMM yyyy";


### PR DESCRIPTION
I think I finally understand why the dependency analyzer has such a tizzy about hamcrest dependencies. 3.0 and 1.3 seem to have put different classes in different artifacts, and JUnit 4 depends on Hamcrest 1.3. As long as we match the Hamcrest version to the JUnit version everything's hunky dory. However if we let dependabot or anything else upgrade to Hamcrest 3, things go haywire. 

See [MDEP-715](https://issues.apache.org/jira/browse/MDEP-715)