### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/alternate-changes-xml-location.md.vm
+++ b/src/site/markdown/examples/alternate-changes-xml-location.md.vm
@@ -1,3 +1,10 @@
+---
+title: Alternate Location for the changes.xml File
+author: 
+  - Dennis Lundberg
+date: 15 July 2006
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/changes-file-validation.md.vm
+++ b/src/site/markdown/examples/changes-file-validation.md.vm
@@ -1,3 +1,10 @@
+---
+title: Validate Your changes.xml File
+author: 
+  - Olivier Lamy
+date: 2011-03-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/check-changes-file.md.vm
+++ b/src/site/markdown/examples/check-changes-file.md.vm
@@ -1,3 +1,10 @@
+---
+title: Check Your changes.xml File
+author: 
+  - Dennis Lundberg
+date: 2011-03-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/configuring-github-report.md.vm
+++ b/src/site/markdown/examples/configuring-github-report.md.vm
@@ -1,3 +1,10 @@
+---
+title: Configuring the GitHub Report
+author: 
+  - Bryan Baugher
+date: 2012-06-21
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/configuring-trac-report.md.vm
+++ b/src/site/markdown/examples/configuring-trac-report.md.vm
@@ -1,3 +1,10 @@
+---
+title: Configuring the Trac Report
+author: 
+  - David Roussel
+date: 2009-10-02
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/customizing-jira-report.md.vm
+++ b/src/site/markdown/examples/customizing-jira-report.md.vm
@@ -1,3 +1,10 @@
+---
+title: Customizing the JIRA Report
+author: 
+  - Dennis Lundberg
+date: 2008-02-10
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/include-announcement-file.md.vm
+++ b/src/site/markdown/examples/include-announcement-file.md.vm
@@ -1,3 +1,10 @@
+---
+title: Include an Announcement File in Your Packaging
+author: 
+  - Dennis Lundberg
+date: 2011-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/smtp-authentication.md.vm
+++ b/src/site/markdown/examples/smtp-authentication.md.vm
@@ -1,3 +1,10 @@
+---
+title: SMTP Authentication
+author: 
+  - Allan Ramirez
+date: 21 October 2005
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/specifying-mail-sender.md.vm
+++ b/src/site/markdown/examples/specifying-mail-sender.md.vm
@@ -1,3 +1,10 @@
+---
+title: Specifying the Mail Sender
+author: 
+  - Stephane Nicoll
+date: 2011-03-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/using-a-custom-announcement-template.md.vm
+++ b/src/site/markdown/examples/using-a-custom-announcement-template.md.vm
@@ -1,3 +1,10 @@
+---
+title: Using a Custom Announcement Template
+author: 
+  - Dennis Lundberg
+date: 2011-03-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Introduction
+author: 
+  - Dennis Lundberg
+date: 2013-07-22
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,12 @@
+---
+title: Usage
+author: 
+  - Johnny R. Ruiz III
+  - Allan Ramirez
+  - Dennis Lundberg
+date: 2011-05-31
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/using-changes-xsd.md
+++ b/src/site/markdown/using-changes-xsd.md
@@ -1,3 +1,10 @@
+---
+title: Using the XML Schema Changes 2.0.0
+author: 
+  - Vincent Siveton
+date: 2009-10-02
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.