### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/src/site/markdown/examples/configuring-trac-report.md.vm
+++ b/src/site/markdown/examples/configuring-trac-report.md.vm
@@ -80,7 +80,7 @@ If your Trac is protected by basic authentication then you'll need to add the `<
 
 #[[### Configuring NTLM Authentication]]#
 
-If you have your Trac sitting behind Apache on Windows with mod\_sspi doing authentication with Active Directory, then the plugin should authenticate to the server as the current user without any extra config. No `<tracUser>` and `<tracPassword>` configuration elements are needed.
+If you have your Trac sitting behind Apache on Windows with mod_sspi doing authentication with Active Directory, then the plugin should authenticate to the server as the current user without any extra config. No `<tracUser>` and `<tracPassword>` configuration elements are needed.
 
 #[[### Using custom encoding]]#
 

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -114,7 +114,7 @@ The following table shows the pre-configured issue management systems and the te
 |System|Issue Link Template|
 |:---|:---|
 |Bitbucket|%URL%/issue/%ISSUE%|
-|Bugzilla|%URL%/show\_bug.cgi?id=%ISSUE%|
+|Bugzilla|%URL%/show_bug.cgi?id=%ISSUE%|
 |GitHub|%URL%/%ISSUE%|
 |GoogleCode|%URL%/detail?id=%ISSUE%|
 |JIRA|%URL%/%ISSUE%|


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.