### PR TITLE
Fail announcement templates on null Velocity values #130

### DIFF
--- a/src/main/java/org/apache/maven/plugins/changes/announcement/AnnouncementMojo.java
+++ b/src/main/java/org/apache/maven/plugins/changes/announcement/AnnouncementMojo.java
@@ -626,11 +626,37 @@ public class AnnouncementMojo extends AbstractAnnouncementMojo {
         } catch (ResourceNotFoundException ex) {
             throw new ResourceNotFoundException(
                     "Template not found. ( " + templateDirectory + "/" + template + " )", ex);
-        } catch (VelocityException ve) {
-            throw ve;
+        } catch (VelocityException | NullPointerException e) {
+            throw announceTemplateFailure(template, e);
         } catch (RuntimeException | IOException e) {
             throw new MojoExecutionException(e.toString(), e);
         }
+    }
+
+    /**
+     * Velocity ends in {@link NullPointerException} when the template calls {@code String.replace} with a null target
+     * or a context field is missing. Surface that as a plugin error instead of a raw NPE.
+     */
+    static MojoExecutionException announceTemplateFailure(String template, Throwable cause) {
+        if (isNullTemplateValue(cause)) {
+            return new MojoExecutionException(
+                    "Failed to process announcement template '" + template
+                            + "': a template value was null. "
+                            + "A required announcement field is missing or the template called String.replace() "
+                            + "with a null target.",
+                    cause);
+        }
+        return new MojoExecutionException(
+                "Failed to process announcement template '" + template + "': " + cause, cause);
+    }
+
+    private static boolean isNullTemplateValue(Throwable cause) {
+        for (Throwable t = cause; t != null; t = t.getCause()) {
+            if (t instanceof NullPointerException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected List<Release> getJiraReleases() throws MojoExecutionException {

--- a/src/test/java/org/apache/maven/plugins/changes/announcement/AnnouncementMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/changes/announcement/AnnouncementMojoTest.java
@@ -25,10 +25,12 @@ import java.nio.file.Files;
 import org.apache.maven.api.plugin.testing.InjectMojo;
 import org.apache.maven.api.plugin.testing.MojoParameter;
 import org.apache.maven.api.plugin.testing.MojoTest;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.plexus.util.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.maven.api.plugin.testing.MojoExtension.getBasedir;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -66,6 +68,23 @@ public class AnnouncementMojoTest {
         assertContains("Removed:", result);
         assertContains("o The element type \" link \" must be terminated by the matching end-tag.", result);
         assertContains("Deleted the erroneous code.", result);
+    }
+
+    @InjectMojo(goal = "announcement-generate", pom = "src/test/unit/plugin-config.xml")
+    @MojoParameter(name = "xmlPath", value = "src/test/unit/announce-changes.xml")
+    @MojoParameter(name = "announcementDirectory", value = "target/test")
+    @MojoParameter(name = "version", value = "1.1")
+    @MojoParameter(name = "finalName", value = "demo-1.0")
+    @MojoParameter(name = "template", value = "null-replace.vm")
+    @MojoParameter(
+            name = "templateDirectory",
+            value = "src/test/resources/org/apache/maven/plugins/changes/announcement")
+    @MojoParameter(name = "introduction", value = "Nice library")
+    @Test
+    public void testAnnounceGenerationFailsWhenReplaceTargetIsNull(AnnouncementMojo mojo) throws Exception {
+        prepareAnnouncementDirectory();
+        MojoExecutionException error = assertThrows(MojoExecutionException.class, mojo::execute);
+        assertTrue(error.getMessage().contains("template value was null"), error.getMessage());
     }
 
     private File prepareAnnouncementDirectory() throws IOException {

--- a/src/test/resources/org/apache/maven/plugins/changes/announcement/null-replace.vm
+++ b/src/test/resources/org/apache/maven/plugins/changes/announcement/null-replace.vm
@@ -1,0 +1,18 @@
+## Licensed to the Apache Software Foundation (ASF) under one
+## or more contributor license agreements.  See the NOTICE file
+## distributed with this work for additional information
+## regarding copyright ownership.  The ASF licenses this file
+## to you under the Apache License, Version 2.0 (the
+## "License"); you may not use this file except in compliance
+## with the License.  You may obtain a copy of the License at
+##
+##  http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing,
+## software distributed under the License is distributed on an
+## "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+## KIND, either express or implied.  See the License for the
+## specific language governing permissions and limitations
+## under the License.
+#set($replaced = $finalName.replace($urlDownload, "x"))
+$replaced


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

`announcement-generate` died with a raw NPE when Velocity called `String.replace` with a null target. I turn that into a `MojoExecutionException` that names the template and says a field was missing.

`AnnouncementMojoTest.testAnnounceGenerationFailsWhenReplaceTargetIsNull` covers it.

Fixes #130
